### PR TITLE
[AutoPR network/resource-manager] [Microsoft.Network] Make id read-only for DdosProtectionPlan by bringing properties from shared resource (Fix RPCViolation)

### DIFF
--- a/azure-mgmt-network/src/main/java/com/microsoft/azure/management/network/implementation/DdosProtectionPlanInner.java
+++ b/azure-mgmt-network/src/main/java/com/microsoft/azure/management/network/implementation/DdosProtectionPlanInner.java
@@ -8,17 +8,47 @@
 
 package com.microsoft.azure.management.network.implementation;
 
+import java.util.Map;
 import java.util.List;
 import com.microsoft.azure.SubResource;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.rest.serializer.JsonFlatten;
-import com.microsoft.azure.Resource;
 
 /**
  * A DDoS protection plan in a resource group.
  */
 @JsonFlatten
-public class DdosProtectionPlanInner extends Resource {
+public class DdosProtectionPlanInner {
+    /**
+     * Resource ID.
+     */
+    @JsonProperty(value = "id", access = JsonProperty.Access.WRITE_ONLY)
+    private String id;
+
+    /**
+     * Resource name.
+     */
+    @JsonProperty(value = "name", access = JsonProperty.Access.WRITE_ONLY)
+    private String name;
+
+    /**
+     * Resource type.
+     */
+    @JsonProperty(value = "type", access = JsonProperty.Access.WRITE_ONLY)
+    private String type;
+
+    /**
+     * Resource location.
+     */
+    @JsonProperty(value = "location")
+    private String location;
+
+    /**
+     * Resource tags.
+     */
+    @JsonProperty(value = "tags")
+    private Map<String, String> tags;
+
     /**
      * The resource GUID property of the DDoS protection plan resource. It
      * uniquely identifies the resource, even if the user changes its name or
@@ -46,6 +76,73 @@ public class DdosProtectionPlanInner extends Resource {
      */
     @JsonProperty(value = "etag", access = JsonProperty.Access.WRITE_ONLY)
     private String etag;
+
+    /**
+     * Get the id value.
+     *
+     * @return the id value
+     */
+    public String id() {
+        return this.id;
+    }
+
+    /**
+     * Get the name value.
+     *
+     * @return the name value
+     */
+    public String name() {
+        return this.name;
+    }
+
+    /**
+     * Get the type value.
+     *
+     * @return the type value
+     */
+    public String type() {
+        return this.type;
+    }
+
+    /**
+     * Get the location value.
+     *
+     * @return the location value
+     */
+    public String location() {
+        return this.location;
+    }
+
+    /**
+     * Set the location value.
+     *
+     * @param location the location value to set
+     * @return the DdosProtectionPlanInner object itself.
+     */
+    public DdosProtectionPlanInner withLocation(String location) {
+        this.location = location;
+        return this;
+    }
+
+    /**
+     * Get the tags value.
+     *
+     * @return the tags value
+     */
+    public Map<String, String> tags() {
+        return this.tags;
+    }
+
+    /**
+     * Set the tags value.
+     *
+     * @param tags the tags value to set
+     * @return the DdosProtectionPlanInner object itself.
+     */
+    public DdosProtectionPlanInner withTags(Map<String, String> tags) {
+        this.tags = tags;
+        return this;
+    }
 
     /**
      * Get the resourceGuid value.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2901